### PR TITLE
modify dead link in docs

### DIFF
--- a/docs/src/main/paradox/full-example.md
+++ b/docs/src/main/paradox/full-example.md
@@ -2,6 +2,6 @@
  
 Take a look at the definition of Actors, their companion objects, and Messages:
  
-@@snip [AkkaQuickstart.scala]($g8src$/scala/$package$/AkkaQuickstart.scala)
+@@snip [AkkaQuickstart.scala](/src/main/g8/src/main/scala/$package$/AkkaQuickstart.scala)
  
 As another best practice we should provide some test coverage.


### PR DESCRIPTION
It seems that there are many dead links in docs(return 404).
First of all, I fixed only full-example.md.