### PR TITLE
Update to sbt 1.3.6 : Correct import statements based on package ente…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 scala:
   - 2.11.11
   - 2.12.6
+  - 2.13.1
 
 before_install:
   # using jabba for custom jdk management

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install: jabba use "$TRAVIS_JDK" && java -Xmx32m -version
 cache:
   directories:
     - $HOME/.ivy2/cache
+    - $HOME/.cache/coursier
     - $HOME/.sbt
     - $HOME/.jabba/jdk
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Prerequisites:
 
 Open a console and run the following command to apply this template:
  ```
-sbt -Dsbt.version=0.13.17 new akka/akka-quickstart-scala.g8
+sbt -Dsbt.version=1.3.6 new akka/akka-quickstart-scala.g8
  ```
 
 This template will prompt for the name of the project. Press `Enter` if the default values suit you.
@@ -28,7 +28,7 @@ sbt run
 
 ## Template license
 
-Written in 2017 by Lightbend, Inc.
+Written in 2019 by Lightbend, Inc.
 
 To the extent possible under law, the author(s) have dedicated all copyright and related
 and neighboring rights to this template to the public domain worldwide.

--- a/build.sbt
+++ b/build.sbt
@@ -16,3 +16,4 @@ lazy val root = (project in file("."))
 //    open docs/target/paradox/site/main/index.html
 lazy val docs = (project in file("docs"))
   .enablePlugins(ParadoxPlugin)
+  .disablePlugins(Giter8Plugin)

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,7 +1,7 @@
 // Uses the out of the box generic theme.
 paradoxTheme := Some(builtinParadoxTheme("generic"))
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.13.1"
 
 paradoxProperties in Compile ++= Map(
   "snip.g8root.base_dir" -> "../../../../src/main/g8"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.6

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.11.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.12.0")

--- a/project/paradox.sbt
+++ b/project/paradox.sbt
@@ -1,2 +1,2 @@
 // sbt-paradox, used for documentation
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.0")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.8")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -10,5 +10,5 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test
+  "org.scalatest" %% "scalatest" % "3.1.0" % Test
 )

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.6

--- a/src/main/g8/src/test/scala/$package$/AkkaQuickstartSpec.scala
+++ b/src/main/g8/src/test/scala/$package$/AkkaQuickstartSpec.scala
@@ -2,8 +2,8 @@
 package $package$
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import com.example.Greeter.Greet
-import com.example.Greeter.Greeted
+import $package$.Greeter.Greet
+import $package$.Greeter.Greeted
 import org.scalatest.WordSpecLike
 
 //#definition


### PR DESCRIPTION
* Upgrade sbt to 1.3.6
* Correct import statements in test to correctly update on the package entered during project creation.