### PR TITLE
fix: Include logging config for classic actor logging

### DIFF
--- a/src/main/g8/src/main/resources/application.conf
+++ b/src/main/g8/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+akka {
+  # logging configuration controlling logging through classic actor APIs
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  # Note: log entries are further filtered by logback configuration
+  loglevel = DEBUG
+}


### PR DESCRIPTION
Just something I noticed when creating a quickstart project and wanted to look at logs