### PR TITLE
bump: Default to Scala 3

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,6 @@
 name = akka-quickstart-scala
 description = Akka is a toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven apps. This simple application will get you started building Actor based systems with Scala. This app uses Akka, Scala, and ScalaTest.
 akka_version=2.9.3
-scala_version=3.3.1
+scala_version=3.3.3
 sbt_version=maven(org.scala-sbt, sbt, stable)
 package=com.example

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,6 @@
 name = akka-quickstart-scala
 description = Akka is a toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven apps. This simple application will get you started building Actor based systems with Scala. This app uses Akka, Scala, and ScalaTest.
 akka_version=2.9.3
-scala_version=2.13.14
+scala_version=3.3.1
 sbt_version=maven(org.scala-sbt, sbt, stable)
 package=com.example


### PR DESCRIPTION
But keep it cross-compilable with 2.13 so users can choose that if they want.