### PR TITLE
build: use global action step

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,6 @@ jobs:
         uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Docs
-        # This runs the template with the default parameters, and runs test within the templated app.
         run: sbt docs/paradox
 
       - name: generate and test, Scala 2.13

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,10 +39,15 @@ jobs:
       - name: Run akka/github-actions-scripts
         uses: akka/github-actions-scripts/setup_global_resolver@main
 
+      - name: Docs
+        # This runs the template with the default parameters, and runs test within the templated app.
+        run: sbt docs/paradox
+
       - name: generate and test, Scala 2.13
         # This runs the template with the default parameters, and runs test within the templated app.
-        run: sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test docs/paradox
+        run: |-
+          sbt new file://$PWD --name=hello-world --scala_version=2.13.18 --force && pushd hello-world && sbt test
 
       - name: generate and test, Scala 3
         run: |-
-          sbt new file://$PWD --name=hello-world --scala_version=3.3.1 --force && pushd hello-world &&  sbt test
+          sbt new file://$PWD --name=hello-world --scala_version=3.3.1 --force && pushd hello-world && sbt test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,6 +36,9 @@ jobs:
         # v6.4.5
         uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: generate and test, Scala 2.13
         # This runs the template with the default parameters, and runs test within the templated app.
         run: sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test docs/paradox

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Once inside the project folder, run the application with:
 sbt run
 ```
 
+## Build Token
+
+To build locally, you need to fetch a token at https://account.akka.io/token that you have to place into `~/.sbt/1.0/akka-commercial.sbt` file like this:
+```
+ThisBuild / resolvers += "lightbend-akka".at("your token resolver here")
+```
+
 ## Template license
 
 Written in 2019 by Lightbend, Inc.

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,8 +4,6 @@ version := "1.0"
 
 scalaVersion := s"$scala_version$"
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 lazy val akkaVersion = "$akka_version$"
 
 // Run in a separate JVM, to make sure sbt waits until all threads have


### PR DESCRIPTION
## Summary

- Added `akka/github-actions-scripts/setup_global_resolver@main` step to the CI workflow
- Removed the `https://repo.akka.io/maven/github_actions` resolver from `src/main/g8/build.sbt`
- Added `## Build Token` section to `README.md` explaining how to fetch and configure a local build token

## Test plan
- [ ] CI workflow runs successfully with the new global resolver action step
- [ ] Template generated projects no longer reference the old `github_actions` resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)